### PR TITLE
make userKey optional for balance change event creation

### DIFF
--- a/src/main/java/com/icthh/xm/ms/balance/service/BalanceService.java
+++ b/src/main/java/com/icthh/xm/ms/balance/service/BalanceService.java
@@ -362,7 +362,8 @@ public class BalanceService {
         event.setBalanceTypeKey(balance.getTypeKey());
         event.setBalanceEntityId(balance.getEntityId());
         event.setExecutedByUserKey(context.getUserKey()
-            .orElseGet(()-> context.getDetailsValue(CLIENT_ID, StringUtils.EMPTY)));
+            .orElseGet(() -> context.getDetailsValue(CLIENT_ID)
+                .orElseThrow(() -> new IllegalArgumentException("Cannot retrieve user origin from token"))));
         event.setOperationType(operationType);
         event.setAmountDelta(amountDelta);
         event.setOperationDate(operationDate);

--- a/src/main/java/com/icthh/xm/ms/balance/service/BalanceService.java
+++ b/src/main/java/com/icthh/xm/ms/balance/service/BalanceService.java
@@ -46,6 +46,7 @@ import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
@@ -357,7 +358,8 @@ public class BalanceService {
         event.setBalanceKey(balance.getKey());
         event.setBalanceTypeKey(balance.getTypeKey());
         event.setBalanceEntityId(balance.getEntityId());
-        event.setExecutedByUserKey(authContextHolder.getContext().getRequiredUserKey());
+        event.setExecutedByUserKey(authContextHolder.getContext().getUserKey()
+            .orElseGet(()-> authContextHolder.getContext().getLogin().orElse(StringUtils.EMPTY)));
         event.setOperationType(operationType);
         event.setAmountDelta(amountDelta);
         event.setOperationDate(operationDate);

--- a/src/main/java/com/icthh/xm/ms/balance/service/BalanceService.java
+++ b/src/main/java/com/icthh/xm/ms/balance/service/BalanceService.java
@@ -66,6 +66,7 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class BalanceService {
 
+    public static final String CLIENT_ID = "client_id";
     private final BalanceRepository balanceRepository;
     private final PermittedRepository permittedRepository;
     private final PocketRepository pocketRepository;
@@ -361,7 +362,7 @@ public class BalanceService {
         event.setBalanceTypeKey(balance.getTypeKey());
         event.setBalanceEntityId(balance.getEntityId());
         event.setExecutedByUserKey(context.getUserKey()
-            .orElseGet(()-> context.getLogin().orElse(StringUtils.EMPTY)));
+            .orElseGet(()-> context.getDetailsValue(CLIENT_ID, StringUtils.EMPTY)));
         event.setOperationType(operationType);
         event.setAmountDelta(amountDelta);
         event.setOperationDate(operationDate);

--- a/src/main/java/com/icthh/xm/ms/balance/service/BalanceService.java
+++ b/src/main/java/com/icthh/xm/ms/balance/service/BalanceService.java
@@ -13,6 +13,7 @@ import com.icthh.xm.commons.lep.LogicExtensionPoint;
 import com.icthh.xm.commons.lep.spring.LepService;
 import com.icthh.xm.commons.permission.annotation.FindWithPermission;
 import com.icthh.xm.commons.permission.repository.PermittedRepository;
+import com.icthh.xm.commons.security.XmAuthenticationContext;
 import com.icthh.xm.commons.security.XmAuthenticationContextHolder;
 import com.icthh.xm.ms.balance.config.ApplicationProperties;
 import com.icthh.xm.ms.balance.domain.Balance;
@@ -353,13 +354,14 @@ public class BalanceService {
                                                         BigDecimal amountDelta, Instant operationDate,
                                                         UUID transactionId, Metadata metadata, BigDecimal amountAfter,
                                                         BigDecimal amountBefore) {
+        XmAuthenticationContext context = authContextHolder.getContext();
         BalanceChangeEvent event = new BalanceChangeEvent();
         event.setBalanceId(balance.getId());
         event.setBalanceKey(balance.getKey());
         event.setBalanceTypeKey(balance.getTypeKey());
         event.setBalanceEntityId(balance.getEntityId());
-        event.setExecutedByUserKey(authContextHolder.getContext().getUserKey()
-            .orElseGet(()-> authContextHolder.getContext().getLogin().orElse(StringUtils.EMPTY)));
+        event.setExecutedByUserKey(context.getUserKey()
+            .orElseGet(()-> context.getLogin().orElse(StringUtils.EMPTY)));
         event.setOperationType(operationType);
         event.setAmountDelta(amountDelta);
         event.setOperationDate(operationDate);

--- a/src/test/java/com/icthh/xm/ms/balance/service/BalanceServiceUnitTest.java
+++ b/src/test/java/com/icthh/xm/ms/balance/service/BalanceServiceUnitTest.java
@@ -98,7 +98,7 @@ public class BalanceServiceUnitTest {
 
     private void expectedAuth() {
         XmAuthenticationContext auth = mock(XmAuthenticationContext.class);
-        when(auth.getRequiredUserKey()).thenReturn("requiredUserKey");
+        when(auth.getUserKey()).thenReturn(Optional.of("requiredUserKey"));
         when(authContextHolder.getContext()).thenReturn(auth);
     }
 


### PR DESCRIPTION
i need to call create/reload api endpoints using jwt without userKey (system token). But here it is mandatory parameter. 